### PR TITLE
chore: tweak line height and margin of generated BF

### DIFF
--- a/report-style.css
+++ b/report-style.css
@@ -13,13 +13,13 @@
 }
 
 @page :first {
-  margin-top: 4mm;
+  margin-top: 2mm;
 }
 
 body {
   font-family: "Flanders Art Sans";
   font-size: 12pt;
-  line-height: 1.5;
+  line-height: 1.8;
   font-variant-ligatures: none;
 }
 
@@ -37,7 +37,6 @@ body {
 
 p {
   margin: 0;
-  margin-bottom: 8pt;
 }
 
 .signature {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4319

Raises the line height slightly to better match the real PDFs, also makes the top margin a bit smaller on the first page to better match the logo distance. Margin between paragraphs has been removed since that's not a thing in Word.

Newly generated BF can be found in ticket.