### PR TITLE
Feature/KAS-4375: Assign filename to virtual file of decision report

### DIFF
--- a/file.ts
+++ b/file.ts
@@ -4,9 +4,7 @@ import {
   sparqlEscapeInt,
   sparqlEscapeDateTime,
   update,
-  uuid as generateUuid,
 } from "mu";
-import { RESOURCE_BASE } from "./config";
 
 export interface FileMeta {
   name: string;
@@ -18,14 +16,13 @@ export interface FileMeta {
   uri: string;
 }
 
-export type FileMetaNoUri = Omit<FileMeta, "uri"> & { uri?: string };
+export type PhysicalFile = FileMeta;
+
+export type VirtualFile = FileMeta & { physicalFile: PhysicalFile };
 
 const createFile = async function (
-  file: FileMetaNoUri,
-  physicalUri: string
-): Promise<FileMeta> {
-  const uri = RESOURCE_BASE + `/files/${file.id}`;
-  const physicalUuid = generateUuid();
+  file: VirtualFile,
+) {
   const q = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
@@ -34,7 +31,7 @@ const createFile = async function (
   PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
   INSERT DATA {
-      ${sparqlEscapeUri(uri)} a nfo:FileDataObject ;
+      ${sparqlEscapeUri(file.uri)} a nfo:FileDataObject ;
             nfo:fileName ${sparqlEscapeString(file.name)} ;
             mu:uuid ${sparqlEscapeString(file.id)} ;
             dct:format ${sparqlEscapeString(file.format)} ;
@@ -42,24 +39,17 @@ const createFile = async function (
             dbpedia:fileExtension ${sparqlEscapeString(file.extension)} ;
             dct:created ${sparqlEscapeDateTime(file.created)} ;
             dct:modified ${sparqlEscapeDateTime(file.created)} .
-      ${sparqlEscapeUri(physicalUri)} a nfo:FileDataObject ;
-            nie:dataSource ${sparqlEscapeUri(uri)} ;
-            nfo:fileName ${sparqlEscapeString(
-              `${physicalUuid}.${file.extension}`
-            )} ;
-            mu:uuid ${sparqlEscapeString(physicalUuid)} ;
-            dct:format ${sparqlEscapeString(file.format)} ;
-            nfo:fileSize ${sparqlEscapeInt(file.size)} ;
-            dbpedia:fileExtension ${sparqlEscapeString(file.extension)} ;
-            dct:created ${sparqlEscapeDateTime(file.created)} ;
-            dct:modified ${sparqlEscapeDateTime(file.created)} .
+      ${sparqlEscapeUri(file.physicalFile.uri)} a nfo:FileDataObject ;
+            nie:dataSource ${sparqlEscapeUri(file.uri)} ;
+            nfo:fileName ${sparqlEscapeString(file.physicalFile.name)} ;
+            mu:uuid ${sparqlEscapeString(file.physicalFile.id)} ;
+            dct:format ${sparqlEscapeString(file.physicalFile.format)} ;
+            nfo:fileSize ${sparqlEscapeInt(file.physicalFile.size)} ;
+            dbpedia:fileExtension ${sparqlEscapeString(file.physicalFile.extension)} ;
+            dct:created ${sparqlEscapeDateTime(file.physicalFile.created)} ;
+            dct:modified ${sparqlEscapeDateTime(file.physicalFile.created)} .
   }`;
   await update(q);
-
-  return {
-    ...file,
-    uri,
-  };
 };
 
 export { createFile };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4375

When we download a file in the app we use the virtual file's filename to hint the downloaded file's name. Before we set a random UUID as the virtual file's filename, which caused the download to suggest a random UUID as filename.

Related PR:
- [ ] https://github.com/kanselarij-vlaanderen/minutes-report-generation-service/pull/7