### PR TITLE
Feature/kas 4394 post test feedback fixes

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -11,4 +11,7 @@ export default {
     PVV: 'http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/9b4701f8-a136-4009-94c6-d64fdc96b9a2',
     ANNEX: 'http://themis.vlaanderen.be/id/concept/vergaderactiviteit-type/30d6a064-8cca-4485-8b37-7ab2357d931d',
   },
+  ACCESS_LEVEL: {
+    CONFIDENTIAL: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17',
+  }
 };

--- a/lib/render-report.ts
+++ b/lib/render-report.ts
@@ -49,8 +49,12 @@ export function renderReport(
   let annotationHtml = `<br />
   <br />`;
   if (reportParts.annotation) {
-    annotationHtml = `<p id="annotation">${reportParts.annotation}</p>
-    <br />`
+    annotationHtml = `<p class="annotation">${reportParts.annotation}</p>
+    <br />`;
+  }
+  let confidentialHtml = '';
+  if (reportContext.accessLevel === constants.ACCESS_LEVEL.CONFIDENTIAL) {
+    confidentialHtml = '<p class="confidential-statement">VERTROUWELIJK</p>';
   }
   let reportHtml = `
   <div lang="nl">
@@ -155,6 +159,7 @@ export function renderReport(
       <p style="font-size: 12pt;">${meetingKindTitle(meeting)}</p>
       <p>________________________________________</p>
     </div>
+    ${confidentialHtml}
     ${annotationHtml}
     <p style="font-weight: 500; text-decoration: underline; font-size: 12pt;">
       ${numberRepresentation} - ${isAnnouncement ? "mededeling" : "punt"}

--- a/lib/report-generation.ts
+++ b/lib/report-generation.ts
@@ -29,6 +29,7 @@ export interface Meeting {
 export type ReportContext = {
   meeting: Meeting;
   agendaItem: AgendaItem;
+  accessLevel: string;
 };
 
 export type AgendaItem = {
@@ -250,10 +251,11 @@ async function retrieveContext(reportId: string): Promise<ReportContext> {
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX schema: <http://schema.org/>
 
-  SELECT DISTINCT ?numberRepresentation ?geplandeStart ?agendaItemNumber ?meetingType ?agendaItemType WHERE {
+  SELECT DISTINCT ?numberRepresentation ?geplandeStart ?agendaItemNumber ?meetingType ?agendaItemType ?accessLevel WHERE {
     ?report mu:uuid ${sparqlEscapeString(reportId)} .
     ?report a besluitvorming:Verslag .
     ?report besluitvorming:beschrijft/^besluitvorming:heeftBeslissing/dct:subject ?agendaItem .
+    ?report besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
     ?agendaItem ^dct:hasPart/besluitvorming:isAgendaVoor ?meeting .
     ?meeting ext:numberRepresentation ?numberRepresentation .
     ?meeting besluit:geplandeStart ?geplandeStart .
@@ -272,6 +274,7 @@ async function retrieveContext(reportId: string): Promise<ReportContext> {
           agendaItemNumber,
           agendaItemType,
           meetingType,
+          accessLevel
         },
       ],
     },
@@ -288,6 +291,7 @@ async function retrieveContext(reportId: string): Promise<ReportContext> {
       isAnnouncement:
         agendaItemType.value === constants.AGENDA_ITEM_TYPES.ANNOUNCEMENT,
     },
+    accessLevel: accessLevel?.value
   };
 }
 

--- a/style/report-style.css
+++ b/style/report-style.css
@@ -57,7 +57,7 @@ table td {
 }
 
 .annotation {
-  font-size: 7pt;
+  font-size: 10pt;
 }
 
 .confidential-statement {

--- a/style/report-style.css
+++ b/style/report-style.css
@@ -46,7 +46,12 @@ p {
 }
 
 .annotation {
-  font-size: 8pt;
+  font-size: 10pt;
+}
+
+.confidential-statement {
+  font-size: 11pt;
+  text-align: center;
 }
 
 .signature {

--- a/style/report-style.css
+++ b/style/report-style.css
@@ -39,6 +39,17 @@ p {
   margin: 0;
 }
 
+table {
+  border: 1px solid black;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table td {
+  border: 1px solid black;
+  padding: 0.6rem;
+}
+
 .part-title {
   font-size: 12pt;
   font-weight: 500;


### PR DESCRIPTION
"VERTROUWELIJK" gecentreerd toevoegen aan vertrouwelijke beslissingsfiches onder de titel boven de annotatie.

De tabellen hadden geen randje in de gegenereerde PDF, maar moeten er wel 1 hebben in beslissingen.