### PR TITLE
fix: use `ORDER BY STR(?reportName)` to order reports

### DIFF
--- a/lib/bundle-generation.ts
+++ b/lib/bundle-generation.ts
@@ -122,7 +122,7 @@ WHERE {
     BIND(IF(BOUND(?flattenedFile), ?flattenedFile , ?originalFile) AS ?physicalFile)
   }
   GRAPH ${sparqlEscapeUri(config.graph.public)} { ?agendaitemType schema:position ?typeOrder }
-} ORDER BY ?typeOrder ?reportName`;
+} ORDER BY ?typeOrder STR(?reportName)`;
 
   let result;
   if (viaJob) {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-1134

Virtuoso for some reason (only on ACC?) orders the reports incorrectly otherwise. This seems to be related to this issue: https://github.com/openlink/virtuoso-opensource/issues/81

Example of badly ordered report bundle: https://kaleidos-test.vlaanderen.be/document/906756c0-b604-11ee-85fe-e9803b71cea0

Couldn't reproduce the actual issue locally (the reports are sorted as expected on my machine) but I could reproduce the query being wrong via the SPARQL endpoint and using `ORDER BY STR(?reportName)` fixed the ordering so I hope this fix should work.