### PR TITLE
KAS-4715 add retracted access level, cleanup some inconsistencies

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -23,9 +23,10 @@ new CronJob(
 );
 
 /* Generate a single report */
-app.get("/:id", async function (req, res, next) {
+app.post("/:id", async function (req, res, next) {
   try {
-    const fileMeta = await generateReport(req.params.id, req.headers);
+    const shouldRegenerateConcerns = req.body.shouldRegenerateConcerns === true;
+    const fileMeta = await generateReport(req.params.id, req.headers, shouldRegenerateConcerns);
     res.status(200).send(fileMeta);
   } catch (e) {
     console.error(e);

--- a/config.ts
+++ b/config.ts
@@ -6,10 +6,6 @@ const PIECE_RESOURCE_BASE = 'http://themis.vlaanderen.be/id/stuk/';
 const DOCUMENT_CONTAINER_RESOURCE_BASE = 'http://themis.vlaanderen.be/id/serie/';
 const FILE_RESOURCE_BASE = 'http://themis.vlaanderen.be/id/bestand/';
 
-const VERTROUWELIJK = 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17';
-const INTERN_OVERHEID = 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46';
-const BESLISSINGSFICHE_TYPE = 'http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e';
-
 const STORAGE_PATH = `/share`;
 const STORAGE_URI = `share://`;
 const graph = {
@@ -41,9 +37,6 @@ export default {
   PIECE_RESOURCE_BASE,
   DOCUMENT_CONTAINER_RESOURCE_BASE,
   FILE_RESOURCE_BASE,
-  VERTROUWELIJK,
-  INTERN_OVERHEID,
-  BESLISSINGSFICHE_TYPE,
   STORAGE_PATH,
   STORAGE_URI,
   graph,

--- a/constants.ts
+++ b/constants.ts
@@ -14,6 +14,7 @@ export default {
   ACCESS_LEVELS: {
     INTERN_SECRETARIE: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17',
+    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9b354d36-250b-43d7-887c-db28fe2fc6fb',
     INTERN_REGERING: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',
@@ -21,7 +22,6 @@ export default {
   DOCUMENT_TYPES: {
     NOTA: 'http://themis.vlaanderen.be/id/concept/document-type/f2b0f655-8ed7-4f61-8f2b-ca813de7a6ed',
     VISIENOTA: 'http://themis.vlaanderen.be/id/concept/document-type/8ae796bd-690a-4ed6-855c-c4572e883066',
-    DECISION: 'http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e',
     MB: 'https://data.vlaanderen.be/id/concept/AardWetgeving/MinisterieelBesluit',
     DECREET: 'https://data.vlaanderen.be/id/concept/AardWetgeving/Decreet',
     BVR: 'https://data.vlaanderen.be/id/concept/AardWetgeving/BesluitVanDeVlaamseRegering',

--- a/constants.ts
+++ b/constants.ts
@@ -14,7 +14,7 @@ export default {
   ACCESS_LEVELS: {
     INTERN_SECRETARIE: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17',
-    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9b354d36-250b-43d7-887c-db28fe2fc6fb',
+    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/969a712a-b3d3-406f-ab08-5f665427185a',
     INTERN_REGERING: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',

--- a/lib/agendaitem.js
+++ b/lib/agendaitem.js
@@ -116,6 +116,11 @@ export async function getAgendaitemPiecesForReport(agendaitemId, isApproval) {
         )} .
       }
       FILTER NOT EXISTS {
+        ?piece besluitvorming:vertrouwelijkheidsniveau ${sparqlEscapeUri(
+          CONSTANTS.ACCESS_LEVELS.INGETROKKEN
+        )} .
+      }
+      FILTER NOT EXISTS {
         [] pav:previousVersion ?piece .
       }
       FILTER NOT EXISTS {

--- a/lib/bundle-generation.ts
+++ b/lib/bundle-generation.ts
@@ -10,6 +10,7 @@ import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import fs from 'fs';
 import { PDFDocument } from "pdf-lib";
 import config from "../config";
+import constants from "../constants";
 import { deleteFile, retrieveContext, storePdf, File } from "./report-generation";
 import { FileMeta, } from "./file";
 
@@ -35,7 +36,7 @@ export async function getReportsForMeeting(
       ?agenda dct:hasPart ?agendaitem .
       ?decisionActivity ^besluitvorming:heeftBeslissing/dct:subject ?agendaitem .
       ?report besluitvorming:beschrijft ?decisionActivity .
-      ?report besluitvorming:vertrouwelijkheidsniveau ${sparqlEscapeUri(config.INTERN_OVERHEID)} .
+      ?report besluitvorming:vertrouwelijkheidsniveau ${sparqlEscapeUri(constants.ACCESS_LEVELS.INTERN_OVERHEID)} .
   
       FILTER NOT EXISTS { ?nextAgenda prov:wasRevisionOf ?agenda }
     }
@@ -154,7 +155,7 @@ async function attachToMeeting(
 
   const now = new Date();
 
-  const accessLevel = config.INTERN_OVERHEID
+  const accessLevel = constants.ACCESS_LEVELS.INTERN_OVERHEID;
 
   const insertPieceQueryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -177,7 +178,7 @@ async function attachToMeeting(
       ${sparqlEscapeUri(documentContainerUri)} a dossier:Serie ;
         mu:uuid ${sparqlEscapeString(documentContainerUuid)} ;
         dct:created ${sparqlEscapeDateTime(now)} ;
-        dct:type ${sparqlEscapeUri(config.BESLISSINGSFICHE_TYPE)} ;
+        dct:type ${sparqlEscapeUri(constants.DOCUMENT_TYPES.BESLISSINGSFICHE)} ;
         dossier:Collectie.bestaatUit ${sparqlEscapeUri(pieceUri)} .
     }
   }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4715

This PR is not technically needed.

In the ticket is requested we treat "retracted" document-type the same as "confidential"
In this service, the behavior of "confidential" is limited to decision reports.
AFAIK, these reports are never retracted?
Or at least doesn't need "CONFIDENTIAL" in the report if "retracted"

TBD:
- will a report will ever be retracted?
- what needs to happen in that case?
- what about retracted documents in the "betreft" part of a decision report? right now they will be listed

Current logic:
An agendaitem can get retracted > "beslissing" part is changed with a standard "item is retracted" text.
Decision reports are either "intern overheid" or "vertrouwelijk" access level


Also:
- config and constants had the same document types, cleaned up.
- decision/beslissingsfiche document type in constants was the same thing, cleaned up "decision"